### PR TITLE
Use https for API access

### DIFF
--- a/taxjar/__init__.py
+++ b/taxjar/__init__.py
@@ -1,4 +1,4 @@
 from taxjar.client import Client
 
-API_URL = 'http://api.taxjar.com/v2/'
+API_URL = 'https://api.taxjar.com/v2/'
 VERSION = '1.1.2'


### PR DESCRIPTION
Not sure why the python library was using `http` when all the rest are using `https`.
  