### PR TITLE
Tweak VAT Validation Method

### DIFF
--- a/taxjar/client.py
+++ b/taxjar/client.py
@@ -118,9 +118,9 @@ class Client(object):
         request = self._get('nexus/regions')
         return self.responder(request)
 
-    def validate(self, vat):
+    def validate(self, vat_deets):
         """Validates an existing VAT identification number against VIES."""
-        request = self._get('validation', {'vat': vat})
+        request = self._get('validation', vat_deets)
         return self.responder(request)
 
     def summary_rates(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -141,7 +141,7 @@ class TestClient(unittest.TestCase):
         self.assert_request_occurred(action, 'get', 'nexus/regions', {})
 
     def test_validate(self):
-        action = lambda _: self.client.validate('1234')
+        action = lambda _: self.client.validate({'vat': '1234'})
         self.assert_request_occurred(action, 'get', 'validation', {'vat': '1234'})
 
     def test_summary_rates(self):


### PR DESCRIPTION
Update VAT `validate` method to receive a dictionary instead of a string to make it consistent with other TaxJar API clients and documentation.