### PR TITLE
Require jsonobject 0.7.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     packages=['taxjar', 'taxjar.data'],
     install_requires=[
         'requests >= 2.13.0',
-        'jsonobject >= 0.7.1'
+        'jsonobject == 0.7.1'
     ],
     tests_require=[
         'mock'


### PR DESCRIPTION
Fixes a build issue with jsonobject 0.9.2 which had a critical bug preventing the library from installing. Just use version 0.7.1 for now.