### PR TITLE
Address Validation

### DIFF
--- a/taxjar/client.py
+++ b/taxjar/client.py
@@ -118,6 +118,11 @@ class Client(object):
         request = self._get('nexus/regions')
         return self.responder(request)
 
+    def validate_address(self, address_deets):
+        """Validates a customer address and returns back a collection of address matches."""
+        request = self._post('addresses/validate', address_deets)
+        return self.responder(request)
+
     def validate(self, vat_deets):
         """Validates an existing VAT identification number against VIES."""
         request = self._get('validation', vat_deets)

--- a/taxjar/data/address.py
+++ b/taxjar/data/address.py
@@ -1,0 +1,14 @@
+from jsonobject import JsonObject, StringProperty
+from taxjar.data.iterable import TaxJarIterable
+
+class TaxJarAddress(JsonObject):
+    country = StringProperty()
+    state = StringProperty()
+    zip = StringProperty()
+    city = StringProperty()
+    street = StringProperty()
+
+class TaxJarAddresses(TaxJarIterable):
+    def handle_response(self, response):
+        self.data = [TaxJarAddress(r) for r in response]
+        return self

--- a/taxjar/factory.py
+++ b/taxjar/factory.py
@@ -4,6 +4,7 @@ from taxjar.data.tax import TaxJarTax
 from taxjar.data.order import TaxJarOrder, TaxJarOrders
 from taxjar.data.customer import TaxJarCustomer, TaxJarCustomers
 from taxjar.data.region import TaxJarRegions
+from taxjar.data.address import TaxJarAddress, TaxJarAddresses
 from taxjar.data.validation import TaxJarValidation
 from taxjar.data.summary_rate import TaxJarSummaryRates
 from taxjar.exceptions import TaxJarTypeError
@@ -22,6 +23,7 @@ class TaxJarTypeFactory(object):
             'customer': TaxJarCustomer,
             'customers': TaxJarCustomers,
             'regions': TaxJarRegions,
+            'addresses': TaxJarAddresses,
             'validation': TaxJarValidation,
             'summary_rates': TaxJarSummaryRates
         }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -140,6 +140,11 @@ class TestClient(unittest.TestCase):
         action = lambda _: self.client.nexus_regions()
         self.assert_request_occurred(action, 'get', 'nexus/regions', {})
 
+    def test_validate_address(self):
+        data = {'country': 'US', 'state': 'AZ', 'zip': '85297', 'city': 'Gilbert', 'street': '3301 South Greenfield Rd'}
+        action = lambda _: self.client.validate_address(data)
+        self.assert_request_occurred(action, 'post', 'addresses/validate', data)
+
     def test_validate(self):
         action = lambda _: self.client.validate({'vat': '1234'})
         self.assert_request_occurred(action, 'get', 'validation', {'vat': '1234'})


### PR DESCRIPTION
This PR adds support for TaxJar's address validation beta endpoint via `validate_address`. At this time, address validation is only available for TaxJar Plus customers.