### PR TITLE
Accept params when showing or deleting transactions

### DIFF
--- a/taxjar/client.py
+++ b/taxjar/client.py
@@ -43,9 +43,9 @@ class Client(object):
         request = self._get('transactions/orders', params)
         return self.responder(request)
 
-    def show_order(self, order_id):
+    def show_order(self, order_id, params=None):
         """Shows an existing order transaction."""
-        request = self._get('transactions/orders/' + str(order_id))
+        request = self._get('transactions/orders/' + str(order_id), params)
         return self.responder(request)
 
     def create_order(self, order_deets):
@@ -58,9 +58,9 @@ class Client(object):
         request = self._put("transactions/orders/" + str(order_id), order_deets)
         return self.responder(request)
 
-    def delete_order(self, order_id):
+    def delete_order(self, order_id, params=None):
         """Deletes an existing order transaction."""
-        request = self._delete("transactions/orders/" + str(order_id))
+        request = self._delete("transactions/orders/" + str(order_id), params)
         return self.responder(request)
 
     def list_refunds(self, params=None):
@@ -68,9 +68,9 @@ class Client(object):
         request = self._get('transactions/refunds', params)
         return self.responder(request)
 
-    def show_refund(self, refund_id):
+    def show_refund(self, refund_id, params=None):
         """Shows an existing refund transaction."""
-        request = self._get('transactions/refunds/' + str(refund_id))
+        request = self._get('transactions/refunds/' + str(refund_id), params)
         return self.responder(request)
 
     def create_refund(self, refund_deets):
@@ -83,9 +83,9 @@ class Client(object):
         request = self._put('transactions/refunds/' + str(refund_id), refund_deets)
         return self.responder(request)
 
-    def delete_refund(self, refund_id):
+    def delete_refund(self, refund_id, params=None):
         """Deletes an existing refund transaction."""
-        request = self._delete('transactions/refunds/' + str(refund_id))
+        request = self._delete('transactions/refunds/' + str(refund_id), params)
         return self.responder(request)
 
     def list_customers(self, params=None):
@@ -144,8 +144,10 @@ class Client(object):
     def _put(self, endpoint, data):
         return self._request(requests.put, endpoint, {'json': data})
 
-    def _delete(self, endpoint):
-        return self._request(requests.delete, endpoint)
+    def _delete(self, endpoint, data=None):
+        if data is None:
+            data = {}
+        return self._request(requests.delete, endpoint, {'params': data})
 
     def _request(self, method, endpoint, data=None):
         if data is None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -74,6 +74,10 @@ class TestClient(unittest.TestCase):
     def test_show_order(self):
         action = lambda _: self.client.show_order('1001')
         self.assert_request_occurred(action, 'get', 'transactions/orders/1001', {})
+        action = lambda _: self.client.show_order('1001', {'provider': 'api'})
+        self.assert_request_occurred(action, 'get', 'transactions/orders/1001', {
+            'provider': 'api'
+        })
 
     def test_create_order(self):
         data = {'dummy': 'data'}
@@ -88,6 +92,10 @@ class TestClient(unittest.TestCase):
     def test_delete_order(self):
         action = lambda _: self.client.delete_order(1)
         self.assert_request_occurred(action, 'delete', 'transactions/orders/1', {})
+        action = lambda _: self.client.delete_order(1, {'provider': 'api'})
+        self.assert_request_occurred(action, 'delete', 'transactions/orders/1', {
+            'provider': 'api'
+        })
 
     def test_list_refunds(self):
         data = {'from_transaction_date': '2016/01/01', 'to_transaction_date': '2017/01/01'}
@@ -99,6 +107,10 @@ class TestClient(unittest.TestCase):
     def test_show_refund(self):
         action = lambda _: self.client.show_refund('1001')
         self.assert_request_occurred(action, 'get', 'transactions/refunds/1001', {})
+        action = lambda _: self.client.show_refund('1001', {'provider': 'api'})
+        self.assert_request_occurred(action, 'get', 'transactions/refunds/1001', {
+            'provider': 'api'
+        })
 
     def test_create_refund(self):
         data = {'dummy': 'data'}
@@ -113,6 +125,10 @@ class TestClient(unittest.TestCase):
     def test_delete_refund(self):
         action = lambda _: self.client.delete_refund(1)
         self.assert_request_occurred(action, 'delete', 'transactions/refunds/1', {})
+        action = lambda _: self.client.delete_refund(1, {'provider': 'api'})
+        self.assert_request_occurred(action, 'delete', 'transactions/refunds/1', {
+            'provider': 'api'
+        })
 
     def test_list_customers(self):
         action = lambda _: self.client.list_customers()
@@ -166,10 +182,8 @@ class TestClient(unittest.TestCase):
 
     def _request_args(self, method, params):
         args = {'timeout': 5}
-        if method == 'get':
+        if method == 'get' or method == 'delete':
             args['params'] = params
-        elif method == 'delete':
-            pass
         else:
             args['json'] = params
         return args


### PR DESCRIPTION
This change adds a second parameter (`params`) to each of the following methods:

- `show_order`
- `delete_order`
- `show_refund`
- `delete_refund`

Using `params`, you can now pass additional parameters to each of the methods such as `provider`:

```python
client.show_refund('123', {'provider': 'api'})
```