### PR TITLE
Add trove classifiers; closes #15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,20 @@ setup(
     url='https://github.com/taxjar/taxjar-python',
     download_url='https://github.com/taxjar/taxjar-python/archive/v1.7.0.zip',
     packages=['taxjar', 'taxjar.data'],
+    classifiers=[
+        "Programming Language :: Python :: 2.6",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Natural Language :: English",
+        "Topic :: Office/Business",
+        "Topic :: Office/Business :: Financial",
+        "Topic :: Office/Business :: Financial :: Accounting",
+        "Topic :: Software Development :: Libraries :: Python Modules"
+    ],
     install_requires=[
         'requests >= 2.13.0',
         'jsonobject == 0.7.1'


### PR DESCRIPTION
This PR adds [trove classifiers](https://pypi.org/classifiers/) for informational purposes as well as to support certain tooling that references the classifiers. This also has the potential to introduce the project to more developers as it will show up, for example, on [PyPi's](https://pypi.org/) results when filtering by classifier.

E.g., after release this will no longer happen:

<img width="1440" alt="Screen Shot 2019-10-16 at 9 45 04 PM" src="https://user-images.githubusercontent.com/26824724/66978384-9e017b00-f05e-11e9-85b1-82640648a307.png">
