### PR TITLE
Fix `update_*` examples and `validate_address` typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,6 @@ import taxjar
 client = taxjar.Client(api_key='48ceecccc8af930bd02597aec0f84a78')
 
 client.update_order('123', {
-    'transaction_id': '123',
     'amount': 283.6,
     'shipping': 5,
     'sales_tax': 1.04,
@@ -726,7 +725,6 @@ import taxjar
 client = taxjar.Client(api_key='48ceecccc8af930bd02597aec0f84a78')
 
 client.update_refund('123-refund', {
-  'transaction_id': '123-refund',
   'transaction_reference_id': '123',
   'amount': -10.35,
   'shipping': -5,
@@ -971,8 +969,7 @@ client.update_customer
 import taxjar
 client = taxjar.Client(api_key='48ceecccc8af930bd02597aec0f84a78')
 
-client.update_customer({
-  'customer_id': '123',
+client.update_customer('123', {
   'exemption_type': 'wholesale',
   'name': 'Sterling Cooper',
   'exempt_regions': [
@@ -1156,7 +1153,7 @@ nexus_regions = client.nexus_regions()
 #### Definition
 
 ```python
-client.nexus_regions
+client.validate_address
 ```
 #### Example Request
 

--- a/tests/run.py
+++ b/tests/run.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
     order = taxjar.show_order(tid)
     print(order)
 
-    order = taxjar.update_order(tid, {'transaction_id': tid, 'from_city': "Santo Barbara"})
+    order = taxjar.update_order(tid, {'from_city': "Santo Barbara"})
     print(order)
 
     order = taxjar.delete_order(tid)
@@ -43,7 +43,7 @@ if __name__ == '__main__':
     order = taxjar.show_refund(tid)
     print(order)
 
-    order = taxjar.update_refund(tid, {'transaction_id': tid, 'from_city': "Santo Barbara", 'amount': 16.5, 'shipping': 2.1, 'sales_tax': 1.1})
+    order = taxjar.update_refund(tid, {'from_city': "Santo Barbara", 'amount': 16.5, 'shipping': 2.1, 'sales_tax': 1.1})
     print(order)
 
     order = taxjar.delete_refund(tid)
@@ -52,7 +52,7 @@ if __name__ == '__main__':
     regions = taxjar.nexus_regions()
     [print(r) for r in regions]
 
-    validation = taxjar.validate("FR40303265045")
+    validation = taxjar.validate({'vat': "FR40303265045"})
     print(validation)
 
     rates = taxjar.summary_rates()


### PR DESCRIPTION
The method definition for `update_customer` is:
```python
def update_customer(self, customer_id, customer_deets):
        """Updates an existing customer."""
        request = self._put("customers/" + str(customer_id), customer_deets)
        return self.responder(request)
```
Similarly, `update_order` and `update_refund` require positional arguments for the ID and "deets."

This PR corrects the examples based on the actual definitions and closes #20.