### PR TITLE
Add more information to custom user agent string

### DIFF
--- a/taxjar/client.py
+++ b/taxjar/client.py
@@ -1,3 +1,7 @@
+import os
+import ssl
+import string
+import sys
 import requests
 import taxjar
 from taxjar.response import TaxJarResponse
@@ -164,9 +168,19 @@ class Client(object):
     def _uri(api_url, endpoint):
         return api_url + endpoint
 
+    @staticmethod
+    def _get_user_agent():
+        platform = ' '.join(os.uname())
+        python_version = '.'.join((str(i) for i in sys.version_info[0:3]))
+        try:
+            open_ssl_version = ssl.OPENSSL_VERSION
+        except AttributeError:
+            open_ssl_version = ''
+        return 'TaxJar/Python (%s; python %s; %s) taxjar-python/%s' % (platform, python_version, open_ssl_version, taxjar.VERSION)
+
     def _default_headers(self):
         return {'Authorization': 'Bearer ' + self.api_key,
-                'User-Agent': 'TaxJarPython/' + taxjar.VERSION}
+                'User-Agent': self._get_user_agent()}
 
     def _headers(self):
         headers = self._default_headers().copy()


### PR DESCRIPTION
To help debug technical issues, it's necessary to collect additional information about a user's server.

For that purpose, this PR adds a custom user agent string to each request, which includes the following information:

- Operating system
- Python version
- OpenSSL version
- Version of taxjar-python currently being used

Example UA string:
<img width="954" alt="Screen Shot 2020-03-26 at 8 57 23 AM" src="https://user-images.githubusercontent.com/26824724/77668048-28b8a100-6f40-11ea-95bc-8b844bc46aa7.png">

