### PR TITLE
Rebrand `SmartCalcs` -> `TaxJar API`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <a href="https://developers.taxjar.com"><img src="https://www.taxjar.com/img/TJ_logo_color_office_png.png" alt="TaxJar" width="220"></a>
 
-Official Python client for [SmartCalcs](https://www.taxjar.com/api/) by [TaxJar](https://www.taxjar.com). For the API documentation, please visit [https://developers.taxjar.com/api](https://developers.taxjar.com/api/reference/?python).
+Official Python client for the [TaxJar API](https://www.taxjar.com/api/). For the API documentation, please visit [https://developers.taxjar.com/api](https://developers.taxjar.com/api/reference/?python).
 
 * This wrapper supports 100% of the [TaxJar API Version 2](https://developers.taxjar.com/api/#introduction)
 * Data returned from API calls are mapped to Python objects
@@ -29,7 +29,7 @@ Python 2.6+ or Python 3+
 
 TaxJar uses the following dependencies as specified in `setup.py`:
 
-* [Requests](https://github.com/kennethreitz/requests) HTTP library for making RESTful requests to SmartCalcs.
+* [Requests](https://github.com/kennethreitz/requests) HTTP library for making RESTful requests to the TaxJar API.
 * [jsonobject](https://github.com/dimagi/jsonobject) Simple JSON object mapping for Python.
 
 ## Getting Started
@@ -1227,7 +1227,7 @@ client.validate({
 
 > Retrieve minimum and average sales tax rates by region as a backup.
 >
-> This method is useful for periodically pulling down rates to use if the SmartCalcs API is unavailable. However, it does not support nexus determination, sourcing based on a ship from and ship to address, shipping taxability, product exemptions, customer exemptions, or sales tax holidays. We recommend using [`tax_for_order` to accurately calculate sales tax for an order](#calculate-sales-tax-for-an-order-api-docs).
+> This method is useful for periodically pulling down rates to use if the TaxJar API is unavailable. However, it does not support nexus determination, sourcing based on a ship from and ship to address, shipping taxability, product exemptions, customer exemptions, or sales tax holidays. We recommend using [`tax_for_order` to accurately calculate sales tax for an order](#calculate-sales-tax-for-an-order-api-docs).
 
 #### Definition
 

--- a/taxjar/data/breakdown_line_item.py
+++ b/taxjar/data/breakdown_line_item.py
@@ -2,7 +2,7 @@ from jsonobject import JsonObject
 from taxjar.data.float_property import TaxJarFloatProperty
 
 class TaxJarBreakdownLineItem(JsonObject):
-    # NB: SmartCalcs can return either string or integer
+    # NB: can return either string or integer
     # `id` is a valid property, but isn't enforced here
     # id = StringProperty()
 

--- a/taxjar/data/line_item.py
+++ b/taxjar/data/line_item.py
@@ -2,7 +2,7 @@ from jsonobject import JsonObject, StringProperty, IntegerProperty
 from taxjar.data.float_property import TaxJarFloatProperty
 
 class TaxJarLineItem(JsonObject):
-    # NB: SmartCalcs can return either string or integer
+    # NB: can return either string or integer
     # `id` is a valid property, but isn't enforced here
     # id = StringProperty()
 


### PR DESCRIPTION
TaxJar is going through a bit of a rebranding:

**SmartCalcs Sales Tax API** is now simplified to **TaxJar Sales Tax API** or **TaxJar API**.