### PR TITLE
Bump up jsonobject to 0.9.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     ],
     install_requires=[
         'requests >= 2.13.0',
-        'jsonobject == 0.7.1'
+        'jsonobject == 0.9.9'
     ],
     tests_require=[
         'mock'


### PR DESCRIPTION
Addresses: https://github.com/taxjar/taxjar-python/issues/27

Previous `jsonobject` versions are incompatible with python-3.9 changes.



