### PR TITLE
Bump jsonobject to 0.9.10+ for Python 3.9 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     ],
     install_requires=[
         'requests >= 2.13.0',
-        'jsonobject == 0.7.1'
+        'jsonobject >= 0.9.10'
     ],
     tests_require=[
         'mock'


### PR DESCRIPTION
Previously we set a fixed version of jsonobject via #10 due to build issues. That issue was fixed in `0.9.3`. To ensure Python 3.9 compatibility, we're bumping jsonobject to `0.9.10` and future versions. Resolves #27