### PR TITLE
Fix syntax warning

### DIFF
--- a/taxjar/client.py
+++ b/taxjar/client.py
@@ -20,7 +20,7 @@ class Client(object):
         self.responder = responder
 
     def set_api_config(self, key, value):
-        if key is 'api_url':
+        if key == 'api_url':
             value += "/" + taxjar.API_VERSION + "/"
         setattr(self, key, value)
 


### PR DESCRIPTION
Fixes a syntax warning that was added in python 3.8:
`taxjar/client.py:23: SyntaxWarning: "is" with a literal. Did you mean "=="?`