### PR TITLE
Use a Requests Session for connection re-use

### DIFF
--- a/taxjar/client.py
+++ b/taxjar/client.py
@@ -18,6 +18,7 @@ class Client(object):
         self.headers = options.get('headers', {})
         self.timeout = options.get('timeout', 5)
         self.responder = responder
+        self.session = requests.Session()
 
     def set_api_config(self, key, value):
         if key is 'api_url':
@@ -140,18 +141,18 @@ class Client(object):
     def _get(self, endpoint, data=None):
         if data is None:
             data = {}
-        return self._request(requests.get, endpoint, {'params': data})
+        return self._request(self.session.get, endpoint, {'params': data})
 
     def _post(self, endpoint, data):
-        return self._request(requests.post, endpoint, {'json': data})
+        return self._request(self.session.post, endpoint, {'json': data})
 
     def _put(self, endpoint, data):
-        return self._request(requests.put, endpoint, {'json': data})
+        return self._request(self.session.put, endpoint, {'json': data})
 
     def _delete(self, endpoint, data=None):
         if data is None:
             data = {}
-        return self._request(requests.delete, endpoint, {'params': data})
+        return self._request(self.session.delete, endpoint, {'params': data})
 
     def _request(self, method, endpoint, data=None):
         if data is None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -170,7 +170,7 @@ class TestClient(unittest.TestCase):
 
     def assert_request_occurred(self, action, request_method, uri, params):
         url = self.api_url + uri
-        with patch.object(requests, request_method) as request_mock:
+        with patch.object(requests.Session, request_method) as request_mock:
             action(0)
             request_mock.assert_called_with(
                 url,


### PR DESCRIPTION
By using a shared session rather than implicitly creating a session for each request, we can benefit from connection re-use.

In addition, via the `session` object on the TaxJar `Client`, users can now control more advanced parameters such as proxy configuration.

If the TaxJar API doesn't use cookies, this should be fully backwards compatible with the TaxJar API. I believe it should also be backwards compatible with any usage in Python codebases as long as the library isn't being monkey-patched.