### PR TITLE
config: update setup.cfg following setuptools update

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
there's an error with builds due to updates from setuptools
changing the field name here fixes that.

see error:
```shell
Using CPython 3.11.10 interpreter at: /usr/local/bin/python3
0.159 Creating virtual environment at: .venv
3.497   × Failed to build `taxjar==2.0.0`
3.497   ├─▶ The build backend returned an error
3.497   ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit
3.497       status: 1)
3.497 
3.497       [stderr]
3.497       Traceback (most recent call last):
3.497         File "<string>", line 14, in <module>
3.497         File
3.497       "/root/.cache/uv/builds-v0/.tmppok9Bi/lib/python3.11/site-packages/setuptools/build_meta.py",
3.497       line 334, in get_requires_for_build_wheel
3.497           return self._get_build_requires(config_settings, requirements=[])
3.497                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
3.497         File
3.497       "/root/.cache/uv/builds-v0/.tmppok9Bi/lib/python3.11/site-packages/setuptools/build_meta.py",
3.497       line 304, in _get_build_requires
3.497           self.run_setup()
3.497         File
3.497       "/root/.cache/uv/builds-v0/.tmppok9Bi/lib/python3.11/site-packages/setuptools/build_meta.py",
3.497       line 522, in run_setup
3.497           super().run_setup(setup_script=setup_script)
3.497         File
3.497       "/root/.cache/uv/builds-v0/.tmppok9Bi/lib/python3.11/site-packages/setuptools/build_meta.py",
3.497       line 320, in run_setup
3.497           exec(code, locals())
3.497         File "<string>", line 3, in <module>
3.497         File
3.497       "/root/.cache/uv/builds-v0/.tmppok9Bi/lib/python3.11/site-packages/setuptools/__init__.py",
3.497       line 116, in setup
3.497           _install_setup_requires(attrs)
3.497         File
3.497       "/root/.cache/uv/builds-v0/.tmppok9Bi/lib/python3.11/site-packages/setuptools/__init__.py",
3.497       line 87, in _install_setup_requires
3.497           dist.parse_config_files(ignore_option_errors=True)
3.497         File
3.497       "/root/.cache/uv/builds-v0/.tmppok9Bi/lib/python3.11/site-packages/_virtualenv.py",
3.497       line 20, in parse_config_files
3.497           result = old_parse_config_files(self, *args, **kwargs)
3.497                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
3.497         File
3.497       "/root/.cache/uv/builds-v0/.tmppok9Bi/lib/python3.11/site-packages/setuptools/dist.py",
3.497       line 730, in parse_config_files
3.497           self._parse_config_files(filenames=inifiles)
3.497         File
3.497       "/root/.cache/uv/builds-v0/.tmppok9Bi/lib/python3.11/site-packages/setuptools/dist.py",
3.497       line 599, in _parse_config_files
3.497           opt = self._enforce_underscore(opt, section)
3.497                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
3.497         File
3.497       "/root/.cache/uv/builds-v0/.tmppok9Bi/lib/python3.11/site-packages/setuptools/dist.py",
3.497       line 629, in _enforce_underscore
3.497           raise InvalidConfigError(
3.497       setuptools.errors.InvalidConfigError: Invalid dash-separated key
3.497       'description-file' in 'metadata' (setup.cfg), please use the underscore
3.497       name 'description_file' instead.
3.497 
3.497       hint: This usually indicates a problem with the package or the build
3.497       environment.
```